### PR TITLE
Add responsive medieval-style main menu

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,41 @@
+body {
+    margin: 0;
+    height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: #2f2a1b;
+    font-family: 'MedievalSharp', cursive;
+}
+
+.menu-container {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    width: 80%;
+    max-width: 400px;
+    gap: 1rem;
+}
+
+.menu-button {
+    font-size: 1.2rem;
+    padding: 0.75rem 1rem;
+    border: 2px solid #d1b86c;
+    background-color: #5b4b2d;
+    color: #ffffff;
+    text-decoration: none;
+    text-align: center;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    box-shadow: 0 2px 0 #000;
+}
+
+.menu-button:hover {
+    background-color: #80663a;
+    box-shadow: 0 4px 2px rgba(0,0,0,0.7);
+    transform: translateY(-2px);
+}
+
+.exit-button {
+    text-decoration: none;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Main Menu</title>
+    <link href="https://fonts.googleapis.com/css2?family=MedievalSharp&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <div class="menu-container">
+        <button class="menu-button">NUOVA PARTITA</button>
+        <button class="menu-button">CARICA PARTITA</button>
+        <button class="menu-button">OPZIONI</button>
+        <button class="menu-button">HALL OF FAME</button>
+        <button class="menu-button">CREDITS</button>
+        <a class="menu-button exit-button" href="https://www.google.com">ESCI DAL GIOCO</a>
+    </div>
+    <script src="js/main.js"></script>
+</body>
+</html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,1 @@
+// Placeholder for main menu interactions


### PR DESCRIPTION
## Summary
- implement main menu in `index.html` with vertical button stack
- add medieval theme styles and hover effects
- include placeholder script

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685269e9f5888326bb7e9cb94034adba