### PR TITLE
Add multilingual options with flag icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 Questo progetto contiene un semplice menù ispirato a "Reigns". Apri `index.html` in un browser per visualizzare il titolo e i pulsanti disposti verticalmente.
 
 Gli stili principali sono definiti in `css/style.css`.
+
+Il menù iniziale permette di selezionare la lingua tramite le icone delle bandiere (italiano, inglese, francese, tedesco, spagnolo e portoghese). La scelta aggiorna tutti i testi dell'interfaccia.
+
+Il pulsante "ESCI DAL GIOCO" apre `https://www.google.com`.

--- a/css/style.css
+++ b/css/style.css
@@ -67,6 +67,20 @@ body {
     width: 100%;
 }
 
+.language-flags {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: center;
+    margin-bottom: 1rem;
+}
+
+.language-flag {
+    width: 40px;
+    height: 26px;
+    cursor: pointer;
+    border: 2px solid #d4af37;
+}
+
 .language-select {
     padding: 0.5rem;
     font-size: 1.2rem;

--- a/index.html
+++ b/index.html
@@ -18,9 +18,21 @@
             <span id="audio-label-text">Audio ON</span>
         </label>
         <input type="range" id="volume-slider" min="0" max="100" value="50">
-        <select id="language-select" class="language-select">
+        <div id="language-flags" class="language-flags">
+            <img src="assets/ui/italiaFlag.svg" class="language-flag" data-lang="it" alt="Italiano">
+            <img src="assets/ui/usaFlag.svg" class="language-flag" data-lang="en" alt="English">
+            <img src="assets/ui/franciaFlag.svg" class="language-flag" data-lang="fr" alt="Français">
+            <img src="assets/ui/germaniaFlag.svg" class="language-flag" data-lang="de" alt="Deutsch">
+            <img src="assets/ui/spagnaFlag.svg" class="language-flag" data-lang="es" alt="Español">
+            <img src="assets/ui/portogalloFlag.svg" class="language-flag" data-lang="pt" alt="Português">
+        </div>
+        <select id="language-select" class="language-select" style="display:none;">
             <option value="it">ITALIANO</option>
             <option value="en">INGLESE</option>
+            <option value="fr">FRANCESE</option>
+            <option value="de">TEDESCO</option>
+            <option value="es">SPAGNOLO</option>
+            <option value="pt">PORTOGHESE</option>
         </select>
         <button id="play-button" class="menu-button">GIOCA</button>
     </div>

--- a/js/main.js
+++ b/js/main.js
@@ -8,6 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const overlay = document.getElementById('splash-overlay');
   const progressBar = document.getElementById('progress-bar');
   const languageSelect = document.getElementById('language-select');
+  const flagButtons = document.querySelectorAll('.language-flag');
   const newGameBtn = document.getElementById('new-game-button');
   const loadGameBtn = document.getElementById('load-game-button');
   const optionsBtn = document.getElementById('options-button');
@@ -26,7 +27,7 @@ document.addEventListener('DOMContentLoaded', () => {
       hall: 'HALL OF FAME',
       credits: 'CREDITS',
       exit: 'ESCI DAL GIOCO',
-      languages: { it: 'ITALIANO', en: 'INGLESE' }
+      languages: { it: 'ITALIANO', en: 'INGLESE', fr: 'FRANCESE', de: 'TEDESCO', es: 'SPAGNOLO', pt: 'PORTOGHESE' }
     },
     en: {
       audioOn: 'Audio ON',
@@ -38,7 +39,55 @@ document.addEventListener('DOMContentLoaded', () => {
       hall: 'HALL OF FAME',
       credits: 'CREDITS',
       exit: 'QUIT GAME',
-      languages: { it: 'ITALIAN', en: 'ENGLISH' }
+      languages: { it: 'ITALIAN', en: 'ENGLISH', fr: 'FRENCH', de: 'GERMAN', es: 'SPANISH', pt: 'PORTUGUESE' }
+    },
+    fr: {
+      audioOn: 'Audio ON',
+      audioOff: 'Audio OFF',
+      play: 'JOUER',
+      newGame: 'NOUVELLE PARTIE',
+      loadGame: 'CHARGER PARTIE',
+      options: 'OPTIONS',
+      hall: 'HALL OF FAME',
+      credits: 'CRÉDITS',
+      exit: 'QUITTER LE JEU',
+      languages: { it: 'ITALIEN', en: 'ANGLAIS', fr: 'FRANÇAIS', de: 'ALLEMAND', es: 'ESPAGNOL', pt: 'PORTUGAIS' }
+    },
+    de: {
+      audioOn: 'Audio AN',
+      audioOff: 'Audio AUS',
+      play: 'SPIELEN',
+      newGame: 'NEUES SPIEL',
+      loadGame: 'SPIEL LADEN',
+      options: 'OPTIONEN',
+      hall: 'RUHMESHALLE',
+      credits: 'CREDITS',
+      exit: 'SPIEL BEENDEN',
+      languages: { it: 'ITALIENISCH', en: 'ENGLISCH', fr: 'FRANZÖSISCH', de: 'DEUTSCH', es: 'SPANISCH', pt: 'PORTUGIESISCH' }
+    },
+    es: {
+      audioOn: 'Audio ON',
+      audioOff: 'Audio OFF',
+      play: 'JUGAR',
+      newGame: 'NUEVA PARTIDA',
+      loadGame: 'CARGAR PARTIDA',
+      options: 'OPCIONES',
+      hall: 'SALA DE LA FAMA',
+      credits: 'CRÉDITOS',
+      exit: 'SALIR DEL JUEGO',
+      languages: { it: 'ITALIANO', en: 'INGLÉS', fr: 'FRANCÉS', de: 'ALEMÁN', es: 'ESPAÑOL', pt: 'PORTUGUÊS' }
+    },
+    pt: {
+      audioOn: 'Audio ON',
+      audioOff: 'Audio OFF',
+      play: 'JOGAR',
+      newGame: 'NOVO JOGO',
+      loadGame: 'CARREGAR JOGO',
+      options: 'OPÇÕES',
+      hall: 'HALL DA FAMA',
+      credits: 'CRÉDITOS',
+      exit: 'SAIR DO JOGO',
+      languages: { it: 'ITALIANO', en: 'INGLÊS', fr: 'FRANCÊS', de: 'ALEMÃO', es: 'ESPANHOL', pt: 'PORTUGUÊS' }
     }
   };
 
@@ -65,11 +114,23 @@ document.addEventListener('DOMContentLoaded', () => {
     exitBtn.textContent = t.exit;
     languageSelect.options[0].textContent = t.languages.it;
     languageSelect.options[1].textContent = t.languages.en;
+    languageSelect.options[2].textContent = t.languages.fr;
+    languageSelect.options[3].textContent = t.languages.de;
+    languageSelect.options[4].textContent = t.languages.es;
+    languageSelect.options[5].textContent = t.languages.pt;
     updateAudioLabel();
   }
 
   audioToggle.addEventListener('change', updateVolumeState);
   languageSelect.addEventListener('change', (e) => updateTexts(e.target.value));
+
+  flagButtons.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const lang = btn.dataset.lang;
+      languageSelect.value = lang;
+      updateTexts(lang);
+    });
+  });
 
   playBtn.addEventListener('click', () => {
     overlay.classList.add('visible');


### PR DESCRIPTION
## Summary
- restore exit link to https://www.google.com
- add language flags for six languages
- update style and main script to switch languages on click
- extend translation strings for Italian, English, French, German, Spanish and Portuguese
- update README with language instructions

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6852796843608326825ff139efb69bf9