### PR TITLE
Add dropdown language selection with warning

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -90,6 +90,33 @@ body {
     color: #ffffff;
 }
 
+.language-select option {
+    background-repeat: no-repeat;
+    background-position: left center, right center;
+    background-size: 24px 16px, 24px 16px;
+    padding-left: 30px;
+    padding-right: 30px;
+}
+
+.lang-option-it { background-image: url('../assets/ui/italiaFlag.svg'), url('../assets/ui/italiaFlag.svg'); }
+.lang-option-en { background-image: url('../assets/ui/usaFlag.svg'), url('../assets/ui/usaFlag.svg'); }
+.lang-option-fr { background-image: url('../assets/ui/franciaFlag.svg'), url('../assets/ui/franciaFlag.svg'); }
+.lang-option-de { background-image: url('../assets/ui/germaniaFlag.svg'), url('../assets/ui/germaniaFlag.svg'); }
+.lang-option-es { background-image: url('../assets/ui/spagnaFlag.svg'), url('../assets/ui/spagnaFlag.svg'); }
+.lang-option-pt { background-image: url('../assets/ui/portogalloFlag.svg'), url('../assets/ui/portogalloFlag.svg'); }
+.lang-option-ar { background-image: url('../assets/ui/arabiaFlag.svg'), url('../assets/ui/arabiaFlag.svg'); }
+.lang-option-ru { background-image: url('../assets/ui/russiaFlag.svg'), url('../assets/ui/russiaFlag.svg'); }
+.lang-option-zh { background-image: url('../assets/ui/cinaFlag.svg'), url('../assets/ui/cinaFlag.svg'); }
+.lang-option-ja { background-image: url('../assets/ui/giapponeFlag.svg'), url('../assets/ui/giapponeFlag.svg'); }
+
+.language-warning {
+    color: #fff;
+    font-family: 'MedievalSharp', cursive;
+    font-size: 0.9rem;
+    text-align: center;
+    margin-top: 0.5rem;
+}
+
 /* Splash overlay */
 #splash-overlay {
     position: fixed;

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="it">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -18,22 +18,20 @@
             <span id="audio-label-text">Audio ON</span>
         </label>
         <input type="range" id="volume-slider" min="0" max="100" value="50">
-        <div id="language-flags" class="language-flags">
-            <img src="assets/ui/italiaFlag.svg" class="language-flag" data-lang="it" alt="Italiano">
-            <img src="assets/ui/usaFlag.svg" class="language-flag" data-lang="en" alt="English">
-            <img src="assets/ui/franciaFlag.svg" class="language-flag" data-lang="fr" alt="Français">
-            <img src="assets/ui/germaniaFlag.svg" class="language-flag" data-lang="de" alt="Deutsch">
-            <img src="assets/ui/spagnaFlag.svg" class="language-flag" data-lang="es" alt="Español">
-            <img src="assets/ui/portogalloFlag.svg" class="language-flag" data-lang="pt" alt="Português">
-        </div>
-        <select id="language-select" class="language-select" style="display:none;">
-            <option value="it">ITALIANO</option>
-            <option value="en">INGLESE</option>
-            <option value="fr">FRANCESE</option>
-            <option value="de">TEDESCO</option>
-            <option value="es">SPAGNOLO</option>
-            <option value="pt">PORTOGHESE</option>
+        <!-- Language selector -->
+        <select id="language-select" class="language-select">
+            <option value="it" class="lang-option-it">ITALIANO</option>
+            <option value="en" class="lang-option-en" selected>INGLESE</option>
+            <option value="fr" class="lang-option-fr">FRANCESE</option>
+            <option value="de" class="lang-option-de">TEDESCO</option>
+            <option value="es" class="lang-option-es">SPAGNOLO</option>
+            <option value="pt" class="lang-option-pt">PORTOGHESE</option>
+            <option value="ar" class="lang-option-ar">ARABO</option>
+            <option value="ru" class="lang-option-ru">RUSSO</option>
+            <option value="zh" class="lang-option-zh">CINESE</option>
+            <option value="ja" class="lang-option-ja">GIAPPONESE</option>
         </select>
+        <p id="language-warning" class="language-warning"></p>
         <button id="play-button" class="menu-button">GIOCA</button>
     </div>
 

--- a/js/main.js
+++ b/js/main.js
@@ -27,7 +27,8 @@ document.addEventListener('DOMContentLoaded', () => {
       hall: 'HALL OF FAME',
       credits: 'CREDITS',
       exit: 'ESCI DAL GIOCO',
-      languages: { it: 'ITALIANO', en: 'INGLESE', fr: 'FRANCESE', de: 'TEDESCO', es: 'SPAGNOLO', pt: 'PORTOGHESE' }
+      warning: 'ATTENZIONE! Questo gioco \u00e8 stato creato in italiano. Le traduzioni in altre lingue sono state generate con l\'intelligenza artificiale e possono contenere degli errori. Vi chiedo scusa in anticipo!',
+      languages: { it: 'ITALIANO', en: 'INGLESE', fr: 'FRANCESE', de: 'TEDESCO', es: 'SPAGNOLO', pt: 'PORTOGHESE', ar: 'ARABO', ru: 'RUSSO', zh: 'CINESE', ja: 'GIAPPONESE' }
     },
     en: {
       audioOn: 'Audio ON',
@@ -39,7 +40,8 @@ document.addEventListener('DOMContentLoaded', () => {
       hall: 'HALL OF FAME',
       credits: 'CREDITS',
       exit: 'QUIT GAME',
-      languages: { it: 'ITALIAN', en: 'ENGLISH', fr: 'FRENCH', de: 'GERMAN', es: 'SPANISH', pt: 'PORTUGUESE' }
+      warning: 'WARNING! This game was originally created in Italian. Translations into other languages were generated with artificial intelligence and may contain errors. I apologize in advance!',
+      languages: { it: 'ITALIAN', en: 'ENGLISH', fr: 'FRENCH', de: 'GERMAN', es: 'SPANISH', pt: 'PORTUGUESE', ar: 'ARABIC', ru: 'RUSSIAN', zh: 'CHINESE', ja: 'JAPANESE' }
     },
     fr: {
       audioOn: 'Audio ON',
@@ -51,7 +53,8 @@ document.addEventListener('DOMContentLoaded', () => {
       hall: 'HALL OF FAME',
       credits: 'CRÉDITS',
       exit: 'QUITTER LE JEU',
-      languages: { it: 'ITALIEN', en: 'ANGLAIS', fr: 'FRANÇAIS', de: 'ALLEMAND', es: 'ESPAGNOL', pt: 'PORTUGAIS' }
+      warning: "ATTENTION ! Ce jeu a été créé en italien. Les traductions dans d'autres langues ont été générées par intelligence artificielle et peuvent contenir des erreurs. Je vous prie de m'excuser par avance !",
+      languages: { it: 'ITALIEN', en: 'ANGLAIS', fr: 'FRANÇAIS', de: 'ALLEMAND', es: 'ESPAGNOL', pt: 'PORTUGAIS', ar: 'ARABE', ru: 'RUSSE', zh: 'CHINOIS', ja: 'JAPONAIS' }
     },
     de: {
       audioOn: 'Audio AN',
@@ -63,7 +66,8 @@ document.addEventListener('DOMContentLoaded', () => {
       hall: 'RUHMESHALLE',
       credits: 'CREDITS',
       exit: 'SPIEL BEENDEN',
-      languages: { it: 'ITALIENISCH', en: 'ENGLISCH', fr: 'FRANZÖSISCH', de: 'DEUTSCH', es: 'SPANISCH', pt: 'PORTUGIESISCH' }
+      warning: 'ACHTUNG! Dieses Spiel wurde auf Italienisch erstellt. Die Übersetzungen in andere Sprachen wurden mit künstlicher Intelligenz erstellt und können Fehler enthalten. Ich entschuldige mich im Voraus!',
+      languages: { it: 'ITALIENISCH', en: 'ENGLISCH', fr: 'FRANZÖSISCH', de: 'DEUTSCH', es: 'SPANISCH', pt: 'PORTUGIESISCH', ar: 'ARABISCH', ru: 'RUSSISCH', zh: 'CHINESISCH', ja: 'JAPANISCH' }
     },
     es: {
       audioOn: 'Audio ON',
@@ -75,7 +79,8 @@ document.addEventListener('DOMContentLoaded', () => {
       hall: 'SALA DE LA FAMA',
       credits: 'CRÉDITOS',
       exit: 'SALIR DEL JUEGO',
-      languages: { it: 'ITALIANO', en: 'INGLÉS', fr: 'FRANCÉS', de: 'ALEMÁN', es: 'ESPAÑOL', pt: 'PORTUGUÊS' }
+      warning: '¡ATENCIÓN! Este juego se ha creado en italiano. Las traducciones a otros idiomas se generaron con inteligencia artificial y pueden contener errores. ¡Les pido disculpas de antemano!',
+      languages: { it: 'ITALIANO', en: 'INGLÉS', fr: 'FRANCÉS', de: 'ALEMÁN', es: 'ESPAÑOL', pt: 'PORTUGUÊS', ar: 'ÁRABE', ru: 'RUSO', zh: 'CHINO', ja: 'JAPONÉS' }
     },
     pt: {
       audioOn: 'Audio ON',
@@ -87,7 +92,60 @@ document.addEventListener('DOMContentLoaded', () => {
       hall: 'HALL DA FAMA',
       credits: 'CRÉDITOS',
       exit: 'SAIR DO JOGO',
-      languages: { it: 'ITALIANO', en: 'INGLÊS', fr: 'FRANCÊS', de: 'ALEMÃO', es: 'ESPANHOL', pt: 'PORTUGUÊS' }
+      warning: 'ATENÇÃO! Este jogo foi criado em italiano. As traduções para outros idiomas foram geradas por inteligência artificial e podem conter erros. Peço desculpas antecipadamente!',
+      languages: { it: 'ITALIANO', en: 'INGLÊS', fr: 'FRANCÊS', de: 'ALEMÃO', es: 'ESPANHOL', pt: 'PORTUGUÊS', ar: 'ÁRABE', ru: 'RUSSO', zh: 'CHINÊS', ja: 'JAPONÊS' }
+    },
+    ar: {
+      audioOn: 'الصوت يعمل',
+      audioOff: 'الصوت متوقف',
+      play: 'ابدأ',
+      newGame: 'لعبة جديدة',
+      loadGame: 'تحميل لعبة',
+      options: 'الإعدادات',
+      hall: 'قاعة الشهرة',
+      credits: 'الشكر والتقدير',
+      exit: 'الخروج من اللعبة',
+      warning: 'تحذير! تم إنشاء هذه اللعبة باللغة الإيطالية. تمت ترجمة اللغات الأخرى باستخدام الذكاء الاصطناعي وقد تحتوي على أخطاء. أعتذر مسبقًا!',
+      languages: { it: 'الإيطالية', en: 'الإنجليزية', fr: 'الفرنسية', de: 'الألمانية', es: 'الإسبانية', pt: 'البرتغالية', ar: 'العربية', ru: 'الروسية', zh: 'الصينية', ja: 'اليابانية' }
+    },
+    ru: {
+      audioOn: 'Звук ВКЛ',
+      audioOff: 'Звук ВЫКЛ',
+      play: 'ИГРАТЬ',
+      newGame: 'НОВАЯ ИГРА',
+      loadGame: 'ЗАГРУЗИТЬ',
+      options: 'НАСТРОЙКИ',
+      hall: 'ЗАЛ СЛАВЫ',
+      credits: 'БЛАГОДАРНОСТИ',
+      exit: 'ВЫХОД',
+      warning: 'ВНИМАНИЕ! Эта игра была создана на итальянском языке. Переводы на другие языки были сгенерированы искусственным интеллектом и могут содержать ошибки. Заранее прошу прощения!',
+      languages: { it: 'Итальянский', en: 'Английский', fr: 'Французский', de: 'Немецкий', es: 'Испанский', pt: 'Португальский', ar: 'Арабский', ru: 'Русский', zh: 'Китайский', ja: 'Японский' }
+    },
+    zh: {
+      audioOn: '声音开启',
+      audioOff: '声音关闭',
+      play: '开始',
+      newGame: '新游戏',
+      loadGame: '加载游戏',
+      options: '选项',
+      hall: '名人堂',
+      credits: '致谢',
+      exit: '退出游戏',
+      warning: '注意！这款游戏原本以意大利语制作。其他语言的翻译由人工智能生成，可能包含错误。提前向您致歉！',
+      languages: { it: '意大利语', en: '英语', fr: '法语', de: '德语', es: '西班牙语', pt: '葡萄牙语', ar: '阿拉伯语', ru: '俄语', zh: '中文', ja: '日语' }
+    },
+    ja: {
+      audioOn: '音声オン',
+      audioOff: '音声オフ',
+      play: 'プレイ',
+      newGame: '新しいゲーム',
+      loadGame: 'ゲームをロード',
+      options: 'オプション',
+      hall: '殿堂',
+      credits: 'クレジット',
+      exit: 'ゲーム終了',
+      warning: '注意！このゲームはイタリア語で作成されています。他の言語への翻訳はAIで生成されており、誤りが含まれている可能性があります。あらかじめご了承ください。',
+      languages: { it: 'イタリア語', en: '英語', fr: 'フランス語', de: 'ドイツ語', es: 'スペイン語', pt: 'ポルトガル語', ar: 'アラビア語', ru: 'ロシア語', zh: '中国語', ja: '日本語' }
     }
   };
 
@@ -118,6 +176,11 @@ document.addEventListener('DOMContentLoaded', () => {
     languageSelect.options[3].textContent = t.languages.de;
     languageSelect.options[4].textContent = t.languages.es;
     languageSelect.options[5].textContent = t.languages.pt;
+    languageSelect.options[6].textContent = t.languages.ar;
+    languageSelect.options[7].textContent = t.languages.ru;
+    languageSelect.options[8].textContent = t.languages.zh;
+    languageSelect.options[9].textContent = t.languages.ja;
+    document.getElementById('language-warning').textContent = t.warning;
     updateAudioLabel();
   }
 


### PR DESCRIPTION
## Summary
- default to English language
- show dropdown selector with text and flags
- add Arabic, Russian, Chinese and Japanese languages
- include localized warning message beneath selector

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68527d5461008326a6aed9eaf5a910d0