### PR TITLE
Lingua dropdown with flag icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ Questo progetto contiene un semplice menù ispirato a "Reigns". Apri `index.html
 
 Gli stili principali sono definiti in `css/style.css`.
 
-Il menù iniziale permette di selezionare la lingua tramite le icone delle bandiere. Sono disponibili italiano, inglese, francese, tedesco, spagnolo, portoghese, arabo, russo, cinese e giapponese. La scelta aggiorna tutti i testi dell'interfaccia.
+Il menù iniziale permette di selezionare la lingua tramite un menu a tendina arricchito con le icone delle bandiere. Sono disponibili italiano, inglese, francese, tedesco, spagnolo, portoghese, arabo, russo, cinese e giapponese. La scelta aggiorna tutti i testi dell'interfaccia.
 
 Il pulsante "ESCI DAL GIOCO" apre `https://www.google.com`.

--- a/css/style.css
+++ b/css/style.css
@@ -82,12 +82,19 @@ body {
 }
 
 .language-select {
+    width: 200px;
+    margin: 0 auto;
     padding: 0.5rem;
     font-size: 1.2rem;
     font-family: 'MedievalSharp', cursive;
     border: 2px solid #d4af37;
     background-color: #74531d;
     color: #ffffff;
+    background-repeat: no-repeat;
+    background-position: left center, right center;
+    background-size: 24px 16px, 24px 16px;
+    padding-left: 30px;
+    padding-right: 30px;
 }
 
 .language-select option {

--- a/index.html
+++ b/index.html
@@ -18,19 +18,6 @@
             <span id="audio-label-text">Audio ON</span>
         </label>
         <input type="range" id="volume-slider" min="0" max="100" value="50">
-        <!-- Language flags -->
-        <div class="language-flags">
-            <img src="assets/ui/italiaFlag.svg" class="language-flag" data-lang="it" alt="Italiano">
-            <img src="assets/ui/usaFlag.svg" class="language-flag" data-lang="en" alt="Inglese">
-            <img src="assets/ui/franciaFlag.svg" class="language-flag" data-lang="fr" alt="Francese">
-            <img src="assets/ui/germaniaFlag.svg" class="language-flag" data-lang="de" alt="Tedesco">
-            <img src="assets/ui/spagnaFlag.svg" class="language-flag" data-lang="es" alt="Spagnolo">
-            <img src="assets/ui/portogalloFlag.svg" class="language-flag" data-lang="pt" alt="Portoghese">
-            <img src="assets/ui/arabiaFlag.svg" class="language-flag" data-lang="ar" alt="Arabo">
-            <img src="assets/ui/russiaFlag.svg" class="language-flag" data-lang="ru" alt="Russo">
-            <img src="assets/ui/cinaFlag.svg" class="language-flag" data-lang="zh" alt="Cinese">
-            <img src="assets/ui/giapponeFlag.svg" class="language-flag" data-lang="ja" alt="Giapponese">
-        </div>
 
         <!-- Language selector -->
         <select id="language-select" class="language-select">

--- a/js/main.js
+++ b/js/main.js
@@ -9,6 +9,18 @@ document.addEventListener('DOMContentLoaded', () => {
   const progressBar = document.getElementById('progress-bar');
   const languageSelect = document.getElementById('language-select');
   const flagButtons = document.querySelectorAll('.language-flag');
+  const flagPaths = {
+    it: 'assets/ui/italiaFlag.svg',
+    en: 'assets/ui/usaFlag.svg',
+    fr: 'assets/ui/franciaFlag.svg',
+    de: 'assets/ui/germaniaFlag.svg',
+    es: 'assets/ui/spagnaFlag.svg',
+    pt: 'assets/ui/portogalloFlag.svg',
+    ar: 'assets/ui/arabiaFlag.svg',
+    ru: 'assets/ui/russiaFlag.svg',
+    zh: 'assets/ui/cinaFlag.svg',
+    ja: 'assets/ui/giapponeFlag.svg'
+  };
   const newGameBtn = document.getElementById('new-game-button');
   const loadGameBtn = document.getElementById('load-game-button');
   const optionsBtn = document.getElementById('options-button');
@@ -155,6 +167,11 @@ document.addEventListener('DOMContentLoaded', () => {
     audioLabelText.textContent = audioToggle.checked ? t.audioOn : t.audioOff;
   }
 
+  function updateSelectFlag(lang) {
+    const flag = flagPaths[lang];
+    languageSelect.style.backgroundImage = `url('${flag}'), url('${flag}')`;
+  }
+
   function updateVolumeState() {
     volumeSlider.disabled = !audioToggle.checked;
     updateAudioLabel();
@@ -182,6 +199,7 @@ document.addEventListener('DOMContentLoaded', () => {
     languageSelect.options[9].textContent = t.languages.ja;
     document.getElementById('language-warning').textContent = t.warning;
     updateAudioLabel();
+    updateSelectFlag(lang);
   }
 
   audioToggle.addEventListener('change', updateVolumeState);


### PR DESCRIPTION
## Summary
- narrow the language select dropdown
- remove the standalone flag buttons
- show current language flag on both sides of the dropdown
- update README to describe new language selection method

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6852831a146083268a2d73d4285d8b13