### PR TITLE
Add language prompt and dropdown hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,6 @@ Gli stili principali sono definiti in `css/style.css`.
 
 Il menù iniziale permette di selezionare la lingua tramite un menu a tendina arricchito con le icone delle bandiere. Sono disponibili italiano, inglese, francese, tedesco, spagnolo, portoghese, arabo, russo, cinese e giapponese. La scelta aggiorna tutti i testi dell'interfaccia.
 
+Sotto il cursore del volume viene mostrato un messaggio localizzato che invita a scegliere la lingua di gioco. Il menu a tendina reagisce al passaggio del mouse cambiando colore e ingrandendosi leggermente per indicare che è cliccabile.
+
 Il pulsante "ESCI DAL GIOCO" apre `https://www.google.com`.

--- a/css/style.css
+++ b/css/style.css
@@ -104,6 +104,14 @@ body {
     border: 2px solid #d4af37;
     background-color: #74531d;
     color: #ffffff;
+    transition: all 0.2s ease;
+}
+
+.language-select:hover {
+    background-color: #b38d48;
+    color: #000;
+    transform: scale(1.05);
+    cursor: pointer;
 }
 
 .language-select option {
@@ -125,6 +133,14 @@ body {
 .lang-option-ru { background-image: url('../assets/ui/russiaFlag.svg'), url('../assets/ui/russiaFlag.svg'); }
 .lang-option-zh { background-image: url('../assets/ui/cinaFlag.svg'), url('../assets/ui/cinaFlag.svg'); }
 .lang-option-ja { background-image: url('../assets/ui/giapponeFlag.svg'), url('../assets/ui/giapponeFlag.svg'); }
+
+.language-prompt {
+    color: #fff;
+    font-family: 'MedievalSharp', cursive;
+    text-align: center;
+    margin-top: 10px;
+    margin-bottom: 5px;
+}
 
 .language-warning {
     color: #fff;

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
             <span id="audio-label-text">Audio ON</span>
         </label>
         <input type="range" id="volume-slider" min="0" max="100" value="50">
+        <p id="language-prompt" class="language-prompt"></p>
 
         <!-- Language selector -->
         <div class="language-container">

--- a/js/main.js
+++ b/js/main.js
@@ -39,6 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
       hall: 'HALL OF FAME',
       credits: 'CREDITS',
       exit: 'ESCI DAL GIOCO',
+      languagePrompt: 'Scegli la lingua di gioco',
       warning: 'ATTENZIONE! Questo gioco \u00e8 stato creato in italiano. Le traduzioni in altre lingue sono state generate con l\'intelligenza artificiale e possono contenere degli errori. Vi chiedo scusa in anticipo!',
       languages: { it: 'ITALIANO', en: 'INGLESE', fr: 'FRANCESE', de: 'TEDESCO', es: 'SPAGNOLO', pt: 'PORTOGHESE', ar: 'ARABO', ru: 'RUSSO', zh: 'CINESE', ja: 'GIAPPONESE' }
     },
@@ -52,6 +53,7 @@ document.addEventListener('DOMContentLoaded', () => {
       hall: 'HALL OF FAME',
       credits: 'CREDITS',
       exit: 'QUIT GAME',
+      languagePrompt: 'Choose the game language',
       warning: 'WARNING! This game was originally created in Italian. Translations into other languages were generated with artificial intelligence and may contain errors. I apologize in advance!',
       languages: { it: 'ITALIAN', en: 'ENGLISH', fr: 'FRENCH', de: 'GERMAN', es: 'SPANISH', pt: 'PORTUGUESE', ar: 'ARABIC', ru: 'RUSSIAN', zh: 'CHINESE', ja: 'JAPANESE' }
     },
@@ -65,6 +67,7 @@ document.addEventListener('DOMContentLoaded', () => {
       hall: 'HALL OF FAME',
       credits: 'CRÉDITS',
       exit: 'QUITTER LE JEU',
+      languagePrompt: 'Choisissez la langue du jeu',
       warning: "ATTENTION ! Ce jeu a été créé en italien. Les traductions dans d'autres langues ont été générées par intelligence artificielle et peuvent contenir des erreurs. Je vous prie de m'excuser par avance !",
       languages: { it: 'ITALIEN', en: 'ANGLAIS', fr: 'FRANÇAIS', de: 'ALLEMAND', es: 'ESPAGNOL', pt: 'PORTUGAIS', ar: 'ARABE', ru: 'RUSSE', zh: 'CHINOIS', ja: 'JAPONAIS' }
     },
@@ -78,6 +81,7 @@ document.addEventListener('DOMContentLoaded', () => {
       hall: 'RUHMESHALLE',
       credits: 'CREDITS',
       exit: 'SPIEL BEENDEN',
+      languagePrompt: 'Wähle die Spielsprache',
       warning: 'ACHTUNG! Dieses Spiel wurde auf Italienisch erstellt. Die Übersetzungen in andere Sprachen wurden mit künstlicher Intelligenz erstellt und können Fehler enthalten. Ich entschuldige mich im Voraus!',
       languages: { it: 'ITALIENISCH', en: 'ENGLISCH', fr: 'FRANZÖSISCH', de: 'DEUTSCH', es: 'SPANISCH', pt: 'PORTUGIESISCH', ar: 'ARABISCH', ru: 'RUSSISCH', zh: 'CHINESISCH', ja: 'JAPANISCH' }
     },
@@ -91,6 +95,7 @@ document.addEventListener('DOMContentLoaded', () => {
       hall: 'SALA DE LA FAMA',
       credits: 'CRÉDITOS',
       exit: 'SALIR DEL JUEGO',
+      languagePrompt: 'Elige el idioma del juego',
       warning: '¡ATENCIÓN! Este juego se ha creado en italiano. Las traducciones a otros idiomas se generaron con inteligencia artificial y pueden contener errores. ¡Les pido disculpas de antemano!',
       languages: { it: 'ITALIANO', en: 'INGLÉS', fr: 'FRANCÉS', de: 'ALEMÁN', es: 'ESPAÑOL', pt: 'PORTUGUÊS', ar: 'ÁRABE', ru: 'RUSO', zh: 'CHINO', ja: 'JAPONÉS' }
     },
@@ -104,6 +109,7 @@ document.addEventListener('DOMContentLoaded', () => {
       hall: 'HALL DA FAMA',
       credits: 'CRÉDITOS',
       exit: 'SAIR DO JOGO',
+      languagePrompt: 'Escolha o idioma do jogo',
       warning: 'ATENÇÃO! Este jogo foi criado em italiano. As traduções para outros idiomas foram geradas por inteligência artificial e podem conter erros. Peço desculpas antecipadamente!',
       languages: { it: 'ITALIANO', en: 'INGLÊS', fr: 'FRANCÊS', de: 'ALEMÃO', es: 'ESPANHOL', pt: 'PORTUGUÊS', ar: 'ÁRABE', ru: 'RUSSO', zh: 'CHINÊS', ja: 'JAPONÊS' }
     },
@@ -117,6 +123,7 @@ document.addEventListener('DOMContentLoaded', () => {
       hall: 'قاعة الشهرة',
       credits: 'الشكر والتقدير',
       exit: 'الخروج من اللعبة',
+      languagePrompt: 'اختر لغة اللعبة',
       warning: 'تحذير! تم إنشاء هذه اللعبة باللغة الإيطالية. تمت ترجمة اللغات الأخرى باستخدام الذكاء الاصطناعي وقد تحتوي على أخطاء. أعتذر مسبقًا!',
       languages: { it: 'الإيطالية', en: 'الإنجليزية', fr: 'الفرنسية', de: 'الألمانية', es: 'الإسبانية', pt: 'البرتغالية', ar: 'العربية', ru: 'الروسية', zh: 'الصينية', ja: 'اليابانية' }
     },
@@ -130,6 +137,7 @@ document.addEventListener('DOMContentLoaded', () => {
       hall: 'ЗАЛ СЛАВЫ',
       credits: 'БЛАГОДАРНОСТИ',
       exit: 'ВЫХОД',
+      languagePrompt: 'Выберите язык игры',
       warning: 'ВНИМАНИЕ! Эта игра была создана на итальянском языке. Переводы на другие языки были сгенерированы искусственным интеллектом и могут содержать ошибки. Заранее прошу прощения!',
       languages: { it: 'Итальянский', en: 'Английский', fr: 'Французский', de: 'Немецкий', es: 'Испанский', pt: 'Португальский', ar: 'Арабский', ru: 'Русский', zh: 'Китайский', ja: 'Японский' }
     },
@@ -143,6 +151,7 @@ document.addEventListener('DOMContentLoaded', () => {
       hall: '名人堂',
       credits: '致谢',
       exit: '退出游戏',
+      languagePrompt: '选择游戏语言',
       warning: '注意！这款游戏原本以意大利语制作。其他语言的翻译由人工智能生成，可能包含错误。提前向您致歉！',
       languages: { it: '意大利语', en: '英语', fr: '法语', de: '德语', es: '西班牙语', pt: '葡萄牙语', ar: '阿拉伯语', ru: '俄语', zh: '中文', ja: '日语' }
     },
@@ -156,6 +165,7 @@ document.addEventListener('DOMContentLoaded', () => {
       hall: '殿堂',
       credits: 'クレジット',
       exit: 'ゲーム終了',
+      languagePrompt: 'ゲームの言語を選択してください',
       warning: '注意！このゲームはイタリア語で作成されています。他の言語への翻訳はAIで生成されており、誤りが含まれている可能性があります。あらかじめご了承ください。',
       languages: { it: 'イタリア語', en: '英語', fr: 'フランス語', de: 'ドイツ語', es: 'スペイン語', pt: 'ポルトガル語', ar: 'アラビア語', ru: 'ロシア語', zh: '中国語', ja: '日本語' }
     }
@@ -201,6 +211,7 @@ document.addEventListener('DOMContentLoaded', () => {
     languageSelect.options[7].textContent = t.languages.ru;
     languageSelect.options[8].textContent = t.languages.zh;
     languageSelect.options[9].textContent = t.languages.ja;
+    document.getElementById('language-prompt').textContent = t.languagePrompt;
     document.getElementById('language-warning').textContent = t.warning;
     updateAudioLabel();
     updateSelectFlag(lang);


### PR DESCRIPTION
## Summary
- show a localized text inviting the user to choose the game language
- highlight the language dropdown on hover
- update translations and texts accordingly
- document the new behaviour in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685286e47cf883268eb45dfbb872cf48